### PR TITLE
docs: clarify offline use for helix renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -16,9 +16,12 @@ Each layer uses the next color from [`data/palette.json`](./data/palette.json). 
 Geometry routines reference sacred numbers 3, 7, 9, 11, 22, 33, 99, and 144 to keep proportions meaningful while staying static.
 
 ## Local Use
-Double-click [index.html](./index.html) in any modern browser. The renderer depends on [`js/helix-renderer.mjs`](./js/helix-renderer.mjs) and optional [`data/palette.json`](./data/palette.json). Everything runs offline.
+Double-click [index.html](./index.html) in any modern browser. The 1440×900 canvas renders immediately with no network calls.
+The renderer depends on [`js/helix-renderer.mjs`](./js/helix-renderer.mjs) and optional [`data/palette.json`](./data/palette.json).
+Everything runs offline.
 
 ## ND-safe Notes
 - No motion or flashing; all elements render statically in layer order.
 - Palette uses gentle contrast for readability.
 - Pure functions, ES modules, UTF-8, and LF newlines.
+


### PR DESCRIPTION
## Summary
- note 1440×900 canvas and offline behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0b29ad6c483289fda6ebc0d6b3c38