### PR TITLE
docs: clarify canvas rationale

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,7 @@
     <div class="status" id="status">Loading palette…</div>
   </header>
 
+  <!-- 1440x900 stage mirrors lattice 144 and soft 9-fold verticals; fixed size prevents sudden resize flashes -->
   <canvas id="stage" width="1440" height="900" aria-label="Layered sacred geometry canvas"></canvas>
   <p class="note">This static renderer encodes Vesica, Tree-of-Life, Fibonacci, and a static double-helix lattice. No animation, no autoplay, no external libs. Open this file directly.</p>
 


### PR DESCRIPTION
## Summary
- clarify in `index.html` why the canvas is a fixed 1440x900 stage tied to numerology and to avoid resize flashes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68c0bb81bdec8328881a13bca22dc3c3