### PR TITLE
chore: honor numerology constants in renderer

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -6,7 +6,7 @@ Static, ND-safe HTML5 canvas renderer for layered sacred geometry. Open [index.h
 
 ## Layers
 1. **Vesica field** – intersecting circles laid out with the constant 3.
-2. **Tree-of-Life** – ten sephirot with twenty-two connecting paths.
+2. **Tree-of-Life** – ten sephirot with twenty-two connecting paths (runtime check keeps the count at 22).
 3. **Fibonacci curve** – fixed logarithmic spiral honoring natural growth.
 4. **Double-helix lattice** – two phase-shifted strands with calm crossbars.
 

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -73,7 +73,11 @@ function drawTreeOfLife(ctx, w, h, color, NUM) {
     [0,1],[0,2],[1,2],[1,3],[2,4],[3,4],[3,5],[4,5],[3,6],[4,7],
     [5,6],[5,7],[6,7],[6,8],[7,8],[6,9],[7,9],[8,9],[1,5],[2,5],
     [0,5],[5,9]
-  ]; // 22 paths honoring NUM.TWENTYTWO
+  ];
+  // honour NUM.TWENTYTWO: ensure path count stays aligned with 22
+  if (paths.length !== NUM.TWENTYTWO) {
+    console.warn("Tree-of-Life path count expected", NUM.TWENTYTWO, "got", paths.length);
+  }
 
   for (const [a, b] of paths) {
     const [ax, ay] = nodes[a];


### PR DESCRIPTION
## Summary
- guard Tree-of-Life paths against drift to honor the number 22
- document the check in the renderer readme

## Testing
- `node tests/interface.test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c11ad153ec8328922dc25aae036c1b