### PR TITLE
Add repository beacon and tidy helix renderer

### DIFF
--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -98,10 +98,6 @@ function drawTreeOfLife(ctx, w, h, color, NUM) {
   if (paths.length !== NUM.TWENTYTWO) {
     console.warn("Tree-of-Life path count expected", NUM.TWENTYTWO, "got", paths.length);
   }
-    [0,1],[0,2],[1,2],[1,3],[2,4],[3,4],[3,5],[4,5],[3,6],[4,7],
-    [5,6],[5,7],[6,7],[6,8],[7,8],[6,9],[7,9],[8,9],[1,5],[2,5],
-    [0,5],[5,9]
-  ]; // 22 paths honoring NUM.TWENTYTWO
 
   for (const { a, b } of paths) {
     const { x: ax, y: ay } = nodeMap[a];

--- a/registry/REPO-BEACON.json
+++ b/registry/REPO-BEACON.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "_about": "Codex 144:99 — Repo Presence Beacon",
+  "alias": "liber-arcanae-game",
+  "name": "Liber Arcanae — Game Engine",
+  "version": "1.0.0",
+  "updated": "2025-09-13T00:00:00Z",
+  "mounts": {
+    "local": "registry/import/",
+    "packs_glob": "registry/import/codex-pack-*.json"
+  },
+  "capabilities": {
+    "codex_nodes": true,
+    "tesseract_scenes": true,
+    "stone_grimoire_chapels": false,
+    "tarot_os_bridge": true
+  },
+  "provenance": {
+    "architect_scribe": "Rebecca Respawn",
+    "license": "CC-BY",
+    "protect": "PROTECT.md"
+  }
+}


### PR DESCRIPTION
## Summary
- add REPO-BEACON.json with repo metadata and capabilities
- clean up helix renderer Tree-of-Life paths and enforce 22-path check

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c5087f662883288b3cdcdbfbd67705