### PR TITLE
Enhance static helix renderer fallbacks and numerology

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -5,20 +5,23 @@ Per Texturas Numerorum, Spira Loquitur.  //
 Static, ND-safe HTML5 canvas renderer for layered sacred geometry. Open [index.html](./index.html) directly in a browser; no build steps or network requests.
 
 ## Layers
-1. **Vesica field** – intersecting circles laid out with the constant 3.
-2. **Tree-of-Life** – ten sephirot with twenty-two connecting paths (runtime check keeps the count at 22).
-3. **Fibonacci curve** – fixed logarithmic spiral honoring natural growth.
-4. **Double-helix lattice** – two phase-shifted strands with calm crossbars.
+1. **Vesica field** - intersecting circles laid out with the constant 3.
+2. **Tree-of-Life** - ten sephirot with twenty-two connecting paths (runtime check keeps the count at 22).
+3. **Fibonacci curve** - fixed logarithmic spiral honoring natural growth.
+4. **Double-helix lattice** - two phase-shifted strands with calm crossbars.
 
 Canonical IDs tag the scaffold: nodes are `C144N-001` through `C144N-010` and gates use `G-099-01` to `G-099-22`.
 
-Each layer uses the next color from [`data/palette.json`](./data/palette.json). If the palette file is missing, a safe fallback loads and a small notice appears.
+Each layer uses the next color from [`data/palette.json`](./data/palette.json). If the palette file is missing, a safe fallback loads and both the header and canvas display a gentle notice.
 
 ## Numerology
 Geometry routines reference sacred numbers 3, 7, 9, 11, 22, 33, 99, and 144 to keep proportions meaningful while staying static.
+- Vesica grid uses a 3x3 layout with radius tied to 9.
+- Fibonacci polyline walks 33 samples with 99-based scaling.
+- Double helix leans on the 22/7 approximation of pi and places 22 crossbars to echo the Tree-of-Life paths.
 
 ## Local Use
-Double-click [index.html](./index.html) in any modern browser. The 1440×900 canvas renders immediately with no network calls.
+Double-click [index.html](./index.html) in any modern browser. The 1440x900 canvas renders immediately with no network calls.
 The renderer depends on [`js/helix-renderer.mjs`](./js/helix-renderer.mjs) and optional [`data/palette.json`](./data/palette.json).
 Everything runs offline.
 

--- a/index.html
+++ b/index.html
@@ -20,8 +20,8 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette…</div>
+    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette...</div>
   </header>
 
   <!-- 1440x900 stage mirrors lattice 144 and soft 9-fold verticals; fixed size prevents sudden resize flashes -->
@@ -34,6 +34,11 @@
     const elStatus = document.getElementById("status");
     const canvas = document.getElementById("stage");
     const ctx = canvas.getContext("2d");
+    if (!ctx) {
+      // ND-safe: acknowledge missing Canvas support instead of failing silently
+      elStatus.textContent = "Canvas context unavailable; static fallback only.";
+      canvas.insertAdjacentHTML("afterend", "<p class=\"note\">Canvas API unavailable in this browser.</p>");
+    }
 
     async function loadJSON(path) {
       try {
@@ -53,15 +58,18 @@
       }
     };
 
-    const palette = await loadJSON("./data/palette.json");
-    const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+    if (ctx) {
+      const palette = await loadJSON("./data/palette.json");
+      const paletteLoaded = Boolean(palette);
+      const active = palette || defaults.palette;
+      elStatus.textContent = paletteLoaded ? "Palette loaded." : "Palette missing; using safe fallback.";
 
-    // Numerology constants used by geometry routines
-    const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
+      // Numerology constants used by geometry routines
+      const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
-    // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+      // ND-safe rationale: no motion, high readability, soft colors, layered order
+      renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM, paletteLoaded });
+    }
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add canvas-context guard and palette fallback notice when data files are missing
- tighten helix numerology by using 22/7 phasing and exactly twenty-two crossbars
- document fallback messaging and numerology details in README_RENDERER

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68c951ba3c288328869c54205f7697a0