### PR TITLE
Remove broken Black Madonna LFS pointer

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 *.hdr  filter=lfs diff=lfs merge=lfs -text
 *.webp filter=lfs diff=lfs merge=lfs -text
 *.psd  filter=lfs diff=lfs merge=lfs -text
+img/black-madonna.png -filter -diff -merge text


### PR DESCRIPTION
## Summary
- add an attribute override so `img/black-madonna.png` bypasses Git LFS filters, leaving other formats unaffected

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cdb663fef483289c86158730c043d2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated repository configuration to standardize handling of a specific image asset in version control (diffing, merging, and filtering).
  * No user-facing changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->