### PR TITLE
Add WEBP art fallback and guard against PNG resurrection

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,4 @@
-*.png  filter=lfs diff=lfs merge=lfs -text
+*.png -filter -diff -merge
 *.tif  filter=lfs diff=lfs merge=lfs -text
 *.tiff filter=lfs diff=lfs merge=lfs -text
 *.exr  filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,7 @@
+# Local caches and OS cruft
 .DS_Store
 Thumbs.db
 __pycache__/
 *.pyc
+node_modules/
+img/black-madonna.png

--- a/assets/art/black-madonna-altar-1600.webp
+++ b/assets/art/black-madonna-altar-1600.webp
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dc526f42f796c6a30055adec7ab27ac7b0ae969769067b0849ab628c8831a450
+size 44

--- a/assets/art/manifest.json
+++ b/assets/art/manifest.json
@@ -1,0 +1,9 @@
+{
+  "_about": "WEBP-only live art",
+  "policy": { "formats": ["webp"], "nd_safe": true },
+  "hero": {
+    "id": "black-madonna-altar",
+    "src": "/assets/art/black-madonna-altar-1600.webp",
+    "alt": "Black Madonna altar in obsidian and opal tones"
+  }
+}

--- a/assets/js/art-loader.js
+++ b/assets/js/art-loader.js
@@ -1,0 +1,25 @@
+// art-loader.js
+// ND-safe art mount: fetch manifest without caching, attach WEBP hero only.
+export async function mountArt(targetId = "hero-art") {
+  const mount = document.getElementById(targetId);
+  if (!mount) return;
+  try {
+    const res = await fetch("/assets/art/manifest.json", { cache: "no-store" });
+    if (!res.ok) throw new Error("manifest fetch failed");
+    const manifest = await res.json();
+    const hero = manifest.hero;
+    if (!hero || !hero.src) {
+      mount.textContent = "Art manifest missing hero entry.";
+      return;
+    }
+    const img = new Image();
+    img.loading = "eager";
+    img.decoding = "async";
+    img.src = hero.src;
+    img.alt = hero.alt || "";
+    mount.innerHTML = "";
+    mount.append(img);
+  } catch (err) {
+    mount.textContent = "Art manifest unavailable. Canvas fallback active.";
+  }
+}

--- a/assets/js/first-paint-octagram.js
+++ b/assets/js/first-paint-octagram.js
@@ -1,0 +1,32 @@
+// first-paint-octagram.js
+// ND-safe fallback painter: static octagram gradient, no motion, offline safe.
+export function paintOctagram(id = "opus", W = 1200, H = 675) {
+  const canvas = document.getElementById(id);
+  if (!canvas) return;
+  canvas.width = W;
+  canvas.height = H;
+  const ctx = canvas.getContext("2d");
+  if (!ctx) return;
+
+  // Layered gradient respects calm palette and depth.
+  const gradient = ctx.createRadialGradient(W / 2, H / 2, 40, W / 2, H / 2, Math.hypot(W, H) / 2);
+  const colors = ["#0F0B1E", "#1d1d20", "#3b2e5a", "#bfa66b", "#dfe8ff"];
+  colors.forEach((col, idx) => gradient.addColorStop(idx / (colors.length - 1), col));
+  ctx.fillStyle = gradient;
+  ctx.fillRect(0, 0, W, H);
+
+  // Static octagram lines - no animation, ND-safe geometry.
+  ctx.globalAlpha = 0.25;
+  ctx.lineWidth = 2;
+  ctx.strokeStyle = "#dfe8ff";
+  const radius = Math.min(W, H) * 0.32;
+  const cx = W / 2;
+  const cy = H / 2;
+  for (let k = 0; k < 8; k++) {
+    const angle = (Math.PI / 4) * k;
+    ctx.beginPath();
+    ctx.moveTo(cx, cy);
+    ctx.lineTo(cx + radius * Math.cos(angle), cy + radius * Math.sin(angle));
+    ctx.stroke();
+  }
+}

--- a/core/health-check.html
+++ b/core/health-check.html
@@ -1,0 +1,18 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>Cathedral Health Check</title>
+<style>
+  body { font:14px ui-monospace,monospace; background:#0b0c10; color:#e6e6e6; padding:2rem; }
+  h1 { margin-top:0; }
+</style>
+<h1>Cathedral Health Check</h1>
+<ul>
+  <li>Build: <script>document.write(new Date(document.lastModified).toISOString());</script></li>
+  <li>Auth: <span id="auth">none</span></li>
+</ul>
+<script>
+  const gated = document.cookie.includes("nf_jwt") || !!window.netlifyIdentity;
+  if (gated) {
+    document.getElementById("auth").textContent = "possible gate detected";
+  }
+</script>

--- a/index.html
+++ b/index.html
@@ -20,8 +20,8 @@
 </head>
 <body>
   <header>
-    <div><strong>Cosmic Helix Renderer</strong> — layered sacred geometry (offline, ND-safe)</div>
-    <div class="status" id="status">Loading palette…</div>
+    <div><strong>Cosmic Helix Renderer</strong> - layered sacred geometry (offline, ND-safe)</div>
+    <div class="status" id="status">Loading palette...</div>
   </header>
 
   <!-- 1440x900 stage mirrors lattice 144 and soft 9-fold verticals; fixed size prevents sudden resize flashes -->

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,2 @@
+[build.environment]
+GIT_LFS_SKIP_SMUDGE = "1"

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "prebuild": "node scripts/verify-absent.mjs",
+    "build": "vite build",
     "test": "node tests/interface.test.js",
     "optimize:images": "node scripts/optimize.mjs",
     "find:dupes": "node scripts/dupes.mjs",
@@ -12,6 +14,7 @@
   "devDependencies": {
     "ajv-cli": "*",
     "imghash": "*",
-    "sharp": "*"
+    "sharp": "*",
+    "vite": "^5.0.0"
   }
 }

--- a/scripts/verify-absent.mjs
+++ b/scripts/verify-absent.mjs
@@ -1,0 +1,13 @@
+// PROTECT charter guard: block forbidden binaries from reviving.
+// ND-safe: small pure script, no network, exits 1 if undead paths return.
+import { existsSync } from "node:fs";
+
+const tombs = ["img/black-madonna.png"]; // extend if more haunted assets appear
+const risen = tombs.filter(p => existsSync(p));
+
+if (risen.length) {
+  console.error("PROTECT violation: undead asset(s) present:", risen);
+  process.exit(1);
+} else {
+  console.log("Guard ok - no undead assets detected.");
+}

--- a/stone-cathedral/chapels/black-madonna/index.html
+++ b/stone-cathedral/chapels/black-madonna/index.html
@@ -1,0 +1,38 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <title>Black Madonna Chapel</title>
+  <link rel="stylesheet" href="/core/atelier.css">
+  <style>
+    /* ND-safe fallback: calm palette, no motion */
+    body { margin:0; background:#0b0c10; color:#e6e6e6; font:16px/1.5 ui-sans-serif,system-ui,-apple-system,Segoe UI,sans-serif; }
+    main { max-width:1200px; margin:0 auto; padding:24px 16px 48px; }
+    header { margin-bottom:24px; }
+    h1 { font-size:28px; margin:0 0 8px; }
+    p { margin:0 0 12px; color:#b2b2c8; }
+    #opus { display:block; width:100%; max-width:1200px; margin:0 auto 16px; border:1px solid #1d1d2a; }
+    #hero-art { min-height:40px; display:flex; justify-content:center; }
+    #hero-art img { max-width:100%; height:auto; box-shadow:0 0 0 1px #1d1d2a; }
+    .note { font-size:14px; color:#8d8dab; }
+  </style>
+</head>
+<body>
+  <main>
+    <header>
+      <h1>Black Madonna Chapel</h1>
+      <p>Static altar with WEBP manifest. Canvas paints first light so visitors see geometry even if the master asset is gated.</p>
+    </header>
+    <canvas id="opus" width="1200" height="675" aria-label="Opalescent octagram field"></canvas>
+    <div id="hero-art" aria-live="polite"></div>
+    <p class="note">Offline first. If the WEBP manifest is missing, the octagram remains as a calm placeholder.</p>
+  </main>
+  <script type="module">
+    import { paintOctagram } from "/assets/js/first-paint-octagram.js";
+    import { mountArt } from "/assets/js/art-loader.js";
+    paintOctagram();
+    mountArt();
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- disable LFS smudging for PNG assets and configure Netlify to skip LFS smudge
- add a prebuild guard that blocks reintroduction of the forbidden PNG path
- publish WEBP art manifest, loader, chapel fallback page, and static health check shell

## Testing
- node scripts/verify-absent.mjs
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68ce54ce6ee0832884179fb40581980d