### PR TITLE
Enhance helix renderer fallbacks

### DIFF
--- a/README_RENDERER.md
+++ b/README_RENDERER.md
@@ -12,13 +12,13 @@ Static, ND-safe HTML5 canvas renderer for layered sacred geometry. Open [index.h
 
 Canonical IDs tag the scaffold: nodes are `C144N-001` through `C144N-010` and gates use `G-099-01` to `G-099-22`.
 
-Each layer uses the next color from [`data/palette.json`](./data/palette.json). If the palette file is missing, a safe fallback loads and a small notice appears.
+Each layer uses the next color from [`data/palette.json`](./data/palette.json). The loader normalizes palettes that provide fewer than four layer colors and updates the page chrome so background and text remain aligned. If the palette file is missing, a safe fallback loads and a small notice appears.
 
 ## Numerology
 Geometry routines reference sacred numbers 3, 7, 9, 11, 22, 33, 99, and 144 to keep proportions meaningful while staying static.
 
 ## Local Use
-Double-click [index.html](./index.html) in any modern browser. The 1440×900 canvas renders immediately with no network calls.
+Double-click [index.html](./index.html) in any modern browser. The 1440×900 canvas renders immediately with no network calls, and if canvas is unavailable (very old browsers) a gentle inline notice explains the fallback.
 The renderer depends on [`js/helix-renderer.mjs`](./js/helix-renderer.mjs) and optional [`data/palette.json`](./data/palette.json).
 Everything runs offline.
 

--- a/index.html
+++ b/index.html
@@ -36,6 +36,7 @@
     const ctx = canvas.getContext("2d");
 
     async function loadJSON(path) {
+      // Offline friendly: try local fetch, fall back silently if blocked by file:// restrictions
       try {
         const res = await fetch(path, { cache: "no-store" });
         if (!res.ok) throw new Error(String(res.status));
@@ -43,6 +44,37 @@
       } catch (err) {
         return null;
       }
+    }
+
+    function normalizePalette(candidate, fallback) {
+      // Ensures four layer colors even if palette.json is trimmed or missing entries
+      const safe = {
+        bg: fallback.bg,
+        ink: fallback.ink,
+        layers: []
+      };
+      if (candidate) {
+        if (typeof candidate.bg === "string") safe.bg = candidate.bg;
+        if (typeof candidate.ink === "string") safe.ink = candidate.ink;
+      }
+      const layers = candidate && Array.isArray(candidate.layers) ? candidate.layers : [];
+      const fallbackLayers = fallback.layers;
+      const required = 4;
+      for (let i = 0; i < required; i++) {
+        const fallbackIndex = i % fallbackLayers.length;
+        const color = typeof layers[i] === "string" ? layers[i] : fallbackLayers[fallbackIndex];
+        safe.layers.push(color);
+      }
+      return safe;
+    }
+
+    function applyPaletteVariables(palette) {
+      // Aligns document chrome with the active palette for consistent ND-safe contrast
+      const rootStyle = document.documentElement.style;
+      rootStyle.setProperty("--bg", palette.bg);
+      rootStyle.setProperty("--ink", palette.ink);
+      document.body.style.background = palette.bg;
+      document.body.style.color = palette.ink;
     }
 
     const defaults = {
@@ -53,15 +85,28 @@
       }
     };
 
-    const palette = await loadJSON("./data/palette.json");
-    const active = palette || defaults.palette;
-    elStatus.textContent = palette ? "Palette loaded." : "Palette missing; using safe fallback.";
+    const paletteData = await loadJSON("./data/palette.json");
+    const paletteForRender = normalizePalette(paletteData, defaults.palette);
+    applyPaletteVariables(paletteForRender);
+
+    const paletteStatus = paletteData ? "Palette loaded." : "Palette missing; using safe fallback.";
+
+    if (!ctx) {
+      elStatus.textContent = paletteStatus + " Canvas rendering unavailable.";
+      // Inline notice keeps the page informative even on legacy browsers
+      const warning = document.createElement("p");
+      warning.className = "note";
+      warning.textContent = "Canvas 2D context is unavailable; layered geometry cannot render, but the palette fallback applied.";
+      canvas.replaceWith(warning);
+      return;
+    }
 
     // Numerology constants used by geometry routines
     const NUM = { THREE:3, SEVEN:7, NINE:9, ELEVEN:11, TWENTYTWO:22, THIRTYTHREE:33, NINETYNINE:99, ONEFORTYFOUR:144 };
 
     // ND-safe rationale: no motion, high readability, soft colors, layered order
-    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:active, NUM });
+    renderHelix(ctx, { width:canvas.width, height:canvas.height, palette:paletteForRender, NUM });
+    elStatus.textContent = paletteStatus + " Geometry rendered.";
   </script>
 </body>
 </html>

--- a/js/helix-renderer.mjs
+++ b/js/helix-renderer.mjs
@@ -16,21 +16,27 @@
 */
 
 export function renderHelix(ctx, opts) {
+  if (!ctx) return; // Defensive guard for legacy environments
   const { width, height, palette, NUM } = opts;
   ctx.clearRect(0, 0, width, height);
   // ND-safe: fill background first to avoid flashes
   ctx.fillStyle = palette.bg;
   ctx.fillRect(0, 0, width, height);
 
+  const layers = Array.isArray(palette.layers) ? palette.layers : [];
+  const fallbackColor = palette.ink;
+  const getColor = index => (typeof layers[index] === "string" ? layers[index] : fallbackColor);
+
   // Layer order preserves depth: base geometry first, lattice last
-  drawVesica(ctx, width, height, palette.layers[0], NUM);
-  drawTreeOfLife(ctx, width, height, palette.layers[1], NUM);
-  drawFibonacciCurve(ctx, width, height, palette.layers[2], NUM);
-  drawHelixLattice(ctx, width, height, palette.layers[3], NUM);
+  drawVesica(ctx, width, height, getColor(0), NUM);
+  drawTreeOfLife(ctx, width, height, getColor(1), NUM);
+  drawFibonacciCurve(ctx, width, height, getColor(2), NUM);
+  drawHelixLattice(ctx, width, height, getColor(3), NUM);
 }
 
 // Layer 1: Vesica field using a 3x3 grid
 function drawVesica(ctx, w, h, color, NUM) {
+  ctx.save();
   const cols = NUM.THREE;
   const rows = NUM.THREE;
   const r = Math.min(w, h) / NUM.NINE; // ND-safe: gentle radius balances the grid
@@ -48,13 +54,16 @@ function drawVesica(ctx, w, h, color, NUM) {
       ctx.stroke();
     }
   }
+  ctx.restore();
 }
 
 // Layer 2: Tree-of-Life scaffold with 10 nodes and 22 paths
 function drawTreeOfLife(ctx, w, h, color, NUM) {
+  ctx.save();
   ctx.strokeStyle = color;
   ctx.fillStyle = color;
   ctx.lineWidth = 1; // ND-safe: thin lines keep focus soft
+  ctx.lineJoin = "round";
 
   const nodes = [
     { id: "C144N-001", x: w / 2, y: h * 0.05 },
@@ -114,10 +123,12 @@ function drawTreeOfLife(ctx, w, h, color, NUM) {
     ctx.arc(x, y, r, 0, Math.PI * 2);
     ctx.fill();
   }
+  ctx.restore();
 }
 
 // Layer 3: Fibonacci curve using 33 segments
 function drawFibonacciCurve(ctx, w, h, color, NUM) {
+  ctx.save();
   const phi = (1 + Math.sqrt(5)) / 2;
   const center = { x: w * 0.75, y: h * 0.3 };
   const scale = Math.min(w, h) / NUM.NINETYNINE;
@@ -132,15 +143,18 @@ function drawFibonacciCurve(ctx, w, h, color, NUM) {
     if (i === 0) ctx.moveTo(x, y); else ctx.lineTo(x, y);
   }
   ctx.stroke();
+  ctx.restore();
 }
 
 // Layer 4: Static double-helix lattice
 function drawHelixLattice(ctx, w, h, color, NUM) {
+  ctx.save();
   const steps = NUM.ONEFORTYFOUR; // 144 vertical steps
   const amp = h / NUM.NINE;
   const mid = h / 2;
   ctx.strokeStyle = color;
   ctx.lineWidth = 1; // ND-safe: fine lines keep lattice subtle
+  ctx.lineCap = "round";
 
   // strand A
   ctx.beginPath();
@@ -171,4 +185,5 @@ function drawHelixLattice(ctx, w, h, color, NUM) {
     ctx.lineTo(x, y2);
     ctx.stroke();
   }
+  ctx.restore();
 }


### PR DESCRIPTION
## Summary
- harden palette loading by normalizing layer colors and applying them to the document theme
- guard the canvas renderer against missing 2D contexts and add inline messaging for legacy browsers
- refresh helix renderer helpers to save/restore drawing state and document the offline fallback in the README

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d03300bc948328a5aad7d37b25554f

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Offline-friendly palette loading with silent fallback when fetch is blocked.
  * Inline notice and safe abort when canvas is unavailable in very old browsers.
  * Palette status messaging reflecting availability and render completion.

* **Improvements**
  * Normalized palette to ensure four layers; applied CSS variables for consistent contrast.
  * More consistent rendering with rounded joins/caps, controlled line widths, and scoped canvas state.

* **Bug Fixes**
  * Safe no-op rendering when canvas context is missing.
  * Robust handling when palette file is missing or incomplete.

* **Documentation**
  * Updated palette handling and local/offline usage guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->