### PR TITLE
feat(liber): add Witch Eye orders pages

### DIFF
--- a/assets/data/interchange.json
+++ b/assets/data/interchange.json
@@ -1,0 +1,487 @@
+{
+  "version": "1.0.0",
+  "scope": "major_arcana_08_21",
+  "orders": [
+    {
+      "id": "order_sulphur",
+      "name": "Order of Sulphur",
+      "element": "Fire",
+      "keywords": [
+        "courage",
+        "transmutation",
+        "ignition"
+      ],
+      "notes": "Fire-facing Witch Eye discipline focused on will and catalytic healing."
+    },
+    {
+      "id": "order_mercury",
+      "name": "Order of Mercury",
+      "element": "Mercury (water-air)",
+      "keywords": [
+        "wisdom",
+        "listening",
+        "adaptive flow"
+      ],
+      "notes": "Mercurial Witch Eye study of reflective flow, dreamwork, and harmonic balance."
+    },
+    {
+      "id": "order_salt",
+      "name": "Order of Salt",
+      "element": "Earth",
+      "keywords": [
+        "stability",
+        "cycles",
+        "equilibrium"
+      ],
+      "notes": "Salt order grounds the Witch Eye through cycles, geomancy, and embodied justice."
+    },
+    {
+      "id": "order_ash",
+      "name": "Order of Ash",
+      "element": "Air",
+      "keywords": [
+        "shadow",
+        "liminality",
+        "liberation"
+      ],
+      "notes": "Ash order metabolizes shadow, oaths, and paradox without motion or flash."
+    },
+    {
+      "id": "order_inner",
+      "name": "Inner Order",
+      "element": "Aether",
+      "keywords": [
+        "integration",
+        "world-bridge",
+        "continuum"
+      ],
+      "notes": "Inner Order keeps the spine of Liber Arcanae — wholeness and cosmogenesis."
+    }
+  ],
+  "cards": [
+    {
+      "id": "MA08",
+      "name": "Strength",
+      "slug": "strength",
+      "arcana": "major",
+      "order_id": "order_sulphur",
+      "order_name": "Order of Sulphur",
+      "order_element": "Fire",
+      "non_living_lineages": [
+        {
+          "id": "strength-lion-s-crown",
+          "title": "Lion's Crown",
+          "kind": "artifact",
+          "keywords": [
+            "Circle + Flame",
+            "Taming the lion"
+          ],
+          "notes": "Rage / Compassionate strength"
+        }
+      ],
+      "appPulls": {
+        "visual": "ND-safe golden-red halo, 417 Hz tone",
+        "music": "Solfeggio 417 Hz",
+        "learning": "Rage / Compassionate strength",
+        "game": "Courage trials in circuitum99",
+        "artifact": "Lion's Crown"
+      },
+      "frequency_hz": 417,
+      "figure": "Morticia Moonbeamer"
+    },
+    {
+      "id": "MA09",
+      "name": "The Hermit",
+      "slug": "the-hermit",
+      "arcana": "major",
+      "order_id": "order_mercury",
+      "order_name": "Order of Mercury",
+      "order_element": "Mercury (water-air)",
+      "non_living_lineages": [
+        {
+          "id": "the-hermit-lantern-of-gnosis",
+          "title": "Lantern of Gnosis",
+          "kind": "artifact",
+          "keywords": [
+            "Circle + Cross",
+            "Light in the dark"
+          ],
+          "notes": "Isolation / Wisdom in solitude"
+        }
+      ],
+      "appPulls": {
+        "visual": "ND-safe lantern glow, 741 Hz tone",
+        "music": "Solfeggio 741 Hz",
+        "learning": "Isolation / Wisdom in solitude",
+        "game": "Hermit cave in Mystery House",
+        "artifact": "Lantern of Gnosis"
+      },
+      "frequency_hz": 741,
+      "figure": "Amiyara Skye"
+    },
+    {
+      "id": "MA10",
+      "name": "Wheel of Fortune",
+      "slug": "wheel-of-fortune",
+      "arcana": "major",
+      "order_id": "order_salt",
+      "order_name": "Order of Salt",
+      "order_element": "Earth",
+      "non_living_lineages": [
+        {
+          "id": "wheel-of-fortune-turning-wheel",
+          "title": "Turning Wheel",
+          "kind": "artifact",
+          "keywords": [
+            "Circle",
+            "Ever-turning wheel"
+          ],
+          "notes": "Fatalism / Embracing cycles"
+        }
+      ],
+      "appPulls": {
+        "visual": "Rotating mandala overlay, 528 Hz tone",
+        "music": "Solfeggio 528 Hz",
+        "learning": "Fatalism / Embracing cycles",
+        "game": "Fortuna chamber in Stone-Grimoire",
+        "artifact": "Turning Wheel"
+      },
+      "frequency_hz": 528,
+      "figure": "Cael Umbra"
+    },
+    {
+      "id": "MA11",
+      "name": "Justice",
+      "slug": "justice",
+      "arcana": "major",
+      "order_id": "order_salt",
+      "order_name": "Order of Salt",
+      "order_element": "Earth",
+      "non_living_lineages": [
+        {
+          "id": "justice-scales-of-truth",
+          "title": "Scales of Truth",
+          "kind": "artifact",
+          "keywords": [
+            "Cross",
+            "Balance of forces"
+          ],
+          "notes": "Judgment / Equanimity"
+        }
+      ],
+      "appPulls": {
+        "visual": "Balanced overlay, 741 Hz tone",
+        "music": "Solfeggio 741 Hz",
+        "learning": "Judgment / Equanimity",
+        "game": "Hall of Scales in Mystery House",
+        "artifact": "Scales of Truth"
+      },
+      "frequency_hz": 741,
+      "figure": "Elyria Nox"
+    },
+    {
+      "id": "MA12",
+      "name": "The Hanged Man",
+      "slug": "the-hanged-man",
+      "arcana": "major",
+      "order_id": "order_mercury",
+      "order_name": "Order of Mercury",
+      "order_element": "Mercury (water-air)",
+      "non_living_lineages": [
+        {
+          "id": "the-hanged-man-rope-of-reversal",
+          "title": "Rope of Reversal",
+          "kind": "artifact",
+          "keywords": [
+            "Cross inverted",
+            "Vision in stillness"
+          ],
+          "notes": "Victimhood / Surrender to transformation"
+        }
+      ],
+      "appPulls": {
+        "visual": "Inverted cross overlay, 963 Hz tone",
+        "music": "Solfeggio 963 Hz",
+        "learning": "Victimhood / Surrender to transformation",
+        "game": "Yggdrasil branch portal",
+        "artifact": "Rope of Reversal"
+      },
+      "frequency_hz": 963,
+      "figure": "Mirror Witch"
+    },
+    {
+      "id": "MA13",
+      "name": "Death",
+      "slug": "death",
+      "arcana": "major",
+      "order_id": "order_ash",
+      "order_name": "Order of Ash",
+      "order_element": "Air",
+      "non_living_lineages": [
+        {
+          "id": "death-scythe-of-transformation",
+          "title": "Scythe of Transformation",
+          "kind": "artifact",
+          "keywords": [
+            "Cross + Flame",
+            "Death is passage"
+          ],
+          "notes": "Fear of loss / Transmutation through grief"
+        }
+      ],
+      "appPulls": {
+        "visual": "Void halo overlay, ND-safe 963 Hz tone",
+        "music": "Solfeggio 963 Hz",
+        "learning": "Fear of loss / Transmutation through grief",
+        "game": "Ann Abyss grimoire portal",
+        "artifact": "Scythe of Transformation"
+      },
+      "frequency_hz": 963,
+      "figure": "Ann Abyss (Shadow)"
+    },
+    {
+      "id": "MA14",
+      "name": "Temperance",
+      "slug": "temperance",
+      "arcana": "major",
+      "order_id": "order_mercury",
+      "order_name": "Order of Mercury",
+      "order_element": "Mercury (water-air)",
+      "non_living_lineages": [
+        {
+          "id": "temperance-mixing-vessels",
+          "title": "Mixing Vessels",
+          "kind": "artifact",
+          "keywords": [
+            "Circle + Cross",
+            "Alchemy of opposites"
+          ],
+          "notes": "Excess / Harmonization"
+        }
+      ],
+      "appPulls": {
+        "visual": "Prism halo overlay, harmonic tones",
+        "music": "Solfeggio 528 Hz",
+        "learning": "Excess / Harmonization",
+        "game": "Alchemy lab portal",
+        "artifact": "Mixing Vessels"
+      },
+      "frequency_hz": 528,
+      "figure": "Lyra Vox"
+    },
+    {
+      "id": "MA15",
+      "name": "The Devil",
+      "slug": "the-devil",
+      "arcana": "major",
+      "order_id": "order_ash",
+      "order_name": "Order of Ash",
+      "order_element": "Air",
+      "non_living_lineages": [
+        {
+          "id": "the-devil-chains-of-paradox",
+          "title": "Chains of Paradox",
+          "kind": "artifact",
+          "keywords": [
+            "Cross + Flame inverted",
+            "Trickster's riddle"
+          ],
+          "notes": "Addiction / Shadow integration"
+        }
+      ],
+      "appPulls": {
+        "visual": "ND-safe paradox overlay, 285 Hz tone",
+        "music": "Solfeggio 285 Hz",
+        "learning": "Addiction / Shadow integration",
+        "game": "Zidaryen riddle grove",
+        "artifact": "Chains of Paradox"
+      },
+      "frequency_hz": 285,
+      "figure": "Scarlet Lady"
+    },
+    {
+      "id": "MA16",
+      "name": "The Tower",
+      "slug": "the-tower",
+      "arcana": "major",
+      "order_id": "order_sulphur",
+      "order_name": "Order of Sulphur",
+      "order_element": "Fire",
+      "non_living_lineages": [
+        {
+          "id": "the-tower-lightning-rod",
+          "title": "Lightning Rod",
+          "kind": "artifact",
+          "keywords": [
+            "Cross struck by flame",
+            "Tower falls"
+          ],
+          "notes": "Hubris / Cleansing destruction"
+        }
+      ],
+      "appPulls": {
+        "visual": "Lightning overlay, 417 Hz tone",
+        "music": "Solfeggio 417 Hz",
+        "learning": "Hubris / Cleansing destruction",
+        "game": "Tower collapse trial",
+        "artifact": "Lightning Rod"
+      },
+      "frequency_hz": 417,
+      "figure": "Fenrix Thorne"
+    },
+    {
+      "id": "MA17",
+      "name": "The Star",
+      "slug": "the-star",
+      "arcana": "major",
+      "order_id": "order_mercury",
+      "order_name": "Order of Mercury",
+      "order_element": "Mercury (water-air)",
+      "non_living_lineages": [
+        {
+          "id": "the-star-water-jar-of-wisdom",
+          "title": "Water Jar of Wisdom",
+          "kind": "artifact",
+          "keywords": [
+            "Circle + Crescent",
+            "Star of guidance"
+          ],
+          "notes": "Hopelessness / Sacred hope"
+        }
+      ],
+      "appPulls": {
+        "visual": "ND-safe star overlay, 852 Hz tone",
+        "music": "Solfeggio 852 Hz",
+        "learning": "Hopelessness / Sacred hope",
+        "game": "Star temple portal",
+        "artifact": "Water Jar of Wisdom"
+      },
+      "frequency_hz": 852,
+      "figure": "Sophia/Gnosis"
+    },
+    {
+      "id": "MA18",
+      "name": "The Moon",
+      "slug": "the-moon",
+      "arcana": "major",
+      "order_id": "order_mercury",
+      "order_name": "Order of Mercury",
+      "order_element": "Mercury (water-air)",
+      "non_living_lineages": [
+        {
+          "id": "the-moon-lunar-mirror",
+          "title": "Lunar Mirror",
+          "kind": "artifact",
+          "keywords": [
+            "Circle + Crescent",
+            "Lunar vision"
+          ],
+          "notes": "Delusion / Intuition"
+        }
+      ],
+      "appPulls": {
+        "visual": "ND-safe moon halo, 852 Hz tone",
+        "music": "Solfeggio 852 Hz",
+        "learning": "Delusion / Intuition",
+        "game": "Vespertine dream gate",
+        "artifact": "Lunar Mirror"
+      },
+      "frequency_hz": 852,
+      "figure": "Moonchild 2000"
+    },
+    {
+      "id": "MA19",
+      "name": "The Sun",
+      "slug": "the-sun",
+      "arcana": "major",
+      "order_id": "order_sulphur",
+      "order_name": "Order of Sulphur",
+      "order_element": "Fire",
+      "non_living_lineages": [
+        {
+          "id": "the-sun-solar-orb",
+          "title": "Solar Orb",
+          "kind": "artifact",
+          "keywords": [
+            "Circle + Flame",
+            "Inner sun"
+          ],
+          "notes": "Ego inflation / Solar vitality"
+        }
+      ],
+      "appPulls": {
+        "visual": "Solar overlay, 528 Hz tone",
+        "music": "Solfeggio 528 Hz",
+        "learning": "Ego inflation / Solar vitality",
+        "game": "Solar chamber in Stone-Grimoire",
+        "artifact": "Solar Orb"
+      },
+      "frequency_hz": 528,
+      "figure": "Rebecca Respawn (Solar Double)"
+    },
+    {
+      "id": "MA20",
+      "name": "Judgment",
+      "slug": "judgment",
+      "arcana": "major",
+      "order_id": "order_mercury",
+      "order_name": "Order of Mercury",
+      "order_element": "Mercury (water-air)",
+      "non_living_lineages": [
+        {
+          "id": "judgment-trumpet-of-awakening",
+          "title": "Trumpet of Awakening",
+          "kind": "artifact",
+          "keywords": [
+            "Cross + Flame",
+            "Call to awakening"
+          ],
+          "notes": "Denial / Revelation"
+        }
+      ],
+      "appPulls": {
+        "visual": "ND-safe trumpet overlay, 963 Hz tone",
+        "music": "Solfeggio 963 Hz",
+        "learning": "Denial / Revelation",
+        "game": "Judgment hall in circuitum99",
+        "artifact": "Trumpet of Awakening"
+      },
+      "frequency_hz": 963,
+      "figure": "Sekhara"
+    },
+    {
+      "id": "MA21",
+      "name": "The World",
+      "slug": "the-world",
+      "arcana": "major",
+      "order_id": "order_inner",
+      "order_name": "Inner Order",
+      "order_element": "Aether",
+      "non_living_lineages": [
+        {
+          "id": "the-world-ouroboros-ring",
+          "title": "Ouroboros Ring",
+          "kind": "artifact",
+          "keywords": [
+            "Circle complete",
+            "All is One"
+          ],
+          "notes": "Fragmentation / Integration"
+        }
+      ],
+      "appPulls": {
+        "visual": "ND-safe Ouroboros overlay, 963 Hz tone",
+        "music": "Solfeggio 963 Hz",
+        "learning": "Fragmentation / Integration",
+        "game": "World gate in circuitum99 + Codex 144:99",
+        "artifact": "Ouroboros Ring"
+      },
+      "frequency_hz": 963,
+      "figure": "LuxCrux Monad"
+    }
+  ],
+  "provenance": {
+    "source": "docs/cards_major_08-21.md",
+    "notes": "Interchange layer binding Witch Eye orders and non-living artifact lineages for majors VIII–XXI."
+  }
+}

--- a/docs/cards_major_08-21.md
+++ b/docs/cards_major_08-21.md
@@ -17,6 +17,8 @@
 - Thought-form: Taming the lion
 - HGA Fragment: Heart of valor
 - Faction: Sulphur
+- Witch Eye Order: Order of Sulphur — fire discipline anchoring Strength's courage trial.
+- Non-living Lineage: Lion's Crown — artifact halo holding the static courage grid.
 - App Pulls: Courage trials in circuitum99
 - Technical: ND-safe golden-red halo, 417 Hz tone
 
@@ -37,6 +39,8 @@
 - Thought-form: Light in the dark
 - HGA Fragment: Flame of gnosis
 - Faction: Mercury
+- Witch Eye Order: Order of Mercury — reflective Witch Eye path for lantern listening.
+- Non-living Lineage: Lantern of Gnosis — artifact beacon storing the solitude teachings.
 - App Pulls: Hermit cave in Mystery House
 - Technical: ND-safe lantern glow, 741 Hz tone
 
@@ -57,6 +61,8 @@
 - Thought-form: Ever-turning wheel
 - HGA Fragment: Spin of fate
 - Faction: Salt
+- Witch Eye Order: Order of Salt — geomantic Witch Eye wheel stabilizing cycles.
+- Non-living Lineage: Turning Wheel — living machine archive without a body.
 - App Pulls: Fortuna chamber in Stone-Grimoire
 - Technical: Rotating mandala overlay, 528 Hz tone
 
@@ -77,6 +83,8 @@
 - Thought-form: Balance of forces
 - HGA Fragment: Feather of Ma'at
 - Faction: Salt
+- Witch Eye Order: Order of Salt — balance practice keeping the Witch Eye grounded.
+- Non-living Lineage: Scales of Truth — ceremonial apparatus carrying the justice lineage.
 - App Pulls: Hall of Scales in Mystery House
 - Technical: Balanced overlay, 741 Hz tone
 
@@ -97,6 +105,8 @@
 - Thought-form: Vision in stillness
 - HGA Fragment: Breath of sacrifice
 - Faction: Mercury
+- Witch Eye Order: Order of Mercury — inversion lessons for mirror sight.
+- Non-living Lineage: Rope of Reversal — non-body tether teaching surrender physics.
 - App Pulls: Yggdrasil branch portal
 - Technical: Inverted cross overlay, 963 Hz tone
 
@@ -117,6 +127,8 @@
 - Thought-form: Death is passage
 - HGA Fragment: Bone key
 - Faction: Ash
+- Witch Eye Order: Order of Ash — shadow metabolizers for oath release.
+- Non-living Lineage: Scythe of Transformation — void-forged tool stewarding grief medicine.
 - App Pulls: Ann Abyss grimoire portal
 - Technical: Void halo overlay, ND-safe 963 Hz tone
 
@@ -137,6 +149,8 @@
 - Thought-form: Alchemy of opposites
 - HGA Fragment: Cup of Sophia
 - Faction: Mercury
+- Witch Eye Order: Order of Mercury — harmonic fusion streamlining helix study.
+- Non-living Lineage: Mixing Vessels — alchemical instruments holding blended teachings.
 - App Pulls: Alchemy lab portal
 - Technical: Prism halo overlay, harmonic tones
 
@@ -157,6 +171,8 @@
 - Thought-form: Trickster's riddle
 - HGA Fragment: Mirror chain
 - Faction: Ash
+- Witch Eye Order: Order of Ash — paradox keepers taming shadow contracts.
+- Non-living Lineage: Chains of Paradox — witch eye cuffs storing oath mechanics.
 - App Pulls: Zidaryen riddle grove
 - Technical: ND-safe paradox overlay, 285 Hz tone
 
@@ -177,6 +193,8 @@
 - Thought-form: Tower falls
 - HGA Fragment: Thunder sigil
 - Faction: Sulphur
+- Witch Eye Order: Order of Sulphur — crisis ignition for tower-clear protocols.
+- Non-living Lineage: Lightning Rod — grounded strike conduit safeguarding the order.
 - App Pulls: Tower collapse trial
 - Technical: Lightning overlay, 417 Hz tone
 
@@ -197,6 +215,8 @@
 - Thought-form: Star of guidance
 - HGA Fragment: Vessel of stars
 - Faction: Mercury
+- Witch Eye Order: Order of Mercury — star-sourcing mercy through reflective flow.
+- Non-living Lineage: Water Jar of Wisdom — reservoir artifact nourishing hopeful study.
 - App Pulls: Star temple portal
 - Technical: ND-safe star overlay, 852 Hz tone
 
@@ -217,6 +237,8 @@
 - Thought-form: Lunar vision
 - HGA Fragment: Lunar thread
 - Faction: Mercury
+- Witch Eye Order: Order of Mercury — dreamstream sutras stabilizing lunar sight.
+- Non-living Lineage: Lunar Mirror — selenite interface reflecting the intuitive lineage.
 - App Pulls: Vespertine dream gate
 - Technical: ND-safe moon halo, 852 Hz tone
 
@@ -237,6 +259,8 @@
 - Thought-form: Inner sun
 - HGA Fragment: Solar core
 - Faction: Sulphur
+- Witch Eye Order: Order of Sulphur — solar resilience for regenerative willwork.
+- Non-living Lineage: Solar Orb — radiant device circulating the sun double's medicine.
 - App Pulls: Solar chamber in Stone-Grimoire
 - Technical: Solar overlay, 528 Hz tone
 
@@ -257,6 +281,8 @@
 - Thought-form: Call to awakening
 - HGA Fragment: Breath of Gabriel
 - Faction: Mercury
+- Witch Eye Order: Order of Mercury — trumpet rite for revelation without shock.
+- Non-living Lineage: Trumpet of Awakening — sonic instrument archiving the call to rise.
 - App Pulls: Judgment hall in circuitum99
 - Technical: ND-safe trumpet overlay, 963 Hz tone
 
@@ -277,6 +303,18 @@
 - Thought-form: All is One
 - HGA Fragment: World egg
 - Faction: Inner Order
+- Witch Eye Order: Inner Order — totality keepers braiding all Witch Eye strands.
+- Non-living Lineage: Ouroboros Ring — cosmic apparatus sealing the continuum loop.
 - App Pulls: World gate in circuitum99 + Codex 144:99
 - Technical: ND-safe Ouroboros overlay, 963 Hz tone
+
+---
+
+## Appendix — Helix Canvas Demo
+
+<iframe src="../index.html" title="Cosmic Helix Starter Canvas" loading="lazy"
+        style="width:100%;max-width:960px;aspect-ratio:16/10;border:1px solid #2a2f3b;border-radius:12px;"
+        allowfullscreen></iframe>
+
+If the iframe is blocked in offline readers, open the [Cosmic Helix Renderer](../index.html) directly.
 


### PR DESCRIPTION
## Summary
- add an interchange dataset binding Witch Eye Orders and non-living artifact lineages for majors VIII–XXI
- extend the major arcana pages with explicit Witch Eye Order and non-living lineage notes and append the helix canvas demo for readers

## Testing
- not run (docs/data updates only)


------
https://chatgpt.com/codex/tasks/task_e_68d1d151ee6483289850e69667a15ae4