### PR TITLE
Potential fix for code scanning alert no. 1: Uncontrolled data used in path expression

### DIFF
--- a/tools/dev-server.js
+++ b/tools/dev-server.js
@@ -10,10 +10,17 @@ const root = path.resolve(__dirname, '..'); // parent directory
 const server = http.createServer(async (req, res) => {
   const reqPath = path.normalize(decodeURI(req.url.split('?')[0]));
   let filePath = path.join(root, reqPath);
+  // Validate that the file path is inside the root directory
+  const absPath = path.resolve(filePath);
+  if (!absPath.startsWith(root + path.sep)) {
+    res.writeHead(403);
+    res.end('Forbidden');
+    return;
+  }
   try {
-    const info = await stat(filePath);
-    if (info.isDirectory()) filePath = path.join(filePath, 'index.html');
-    const data = await readFile(filePath);
+    const info = await stat(absPath);
+    if (info.isDirectory()) absPath = path.join(absPath, 'index.html');
+    const data = await readFile(absPath);
     res.writeHead(200);
     res.end(data);
   } catch (err) {


### PR DESCRIPTION
Potential fix for [https://github.com/Bekalah/liber-arcanae-game/security/code-scanning/1](https://github.com/Bekalah/liber-arcanae-game/security/code-scanning/1)

To fix the problem, we need to ensure that user-controlled data (`req.url`) does not allow access to files outside the intended root directory. The best solution is to:

1. After constructing the file path (`filePath`), resolve its absolute path (using `path.resolve`).
2. Use `readFile` and `stat` on the file only if the resolved absolute path is still under the trusted `root` directory. This can be verified by checking that the absolute file path starts with the root directory path.
3. If the file is outside the root, respond with a 403 Forbidden status code.

The required changes are within the `createServer` callback: after constructing `filePath` and before any file operations, resolve the full path and enforce the constraint, rejecting any request that escapes the root.

No extra external dependencies are needed; all functionality is available via the Node.js built-in `path` module.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
