### PR TITLE
Potential fix for code scanning alert no. 3: Uncontrolled data used in path expression

### DIFF
--- a/tools/dev-server.mjs
+++ b/tools/dev-server.mjs
@@ -24,7 +24,12 @@ const types = {
 
 const server = http.createServer(async (req, res) => {
   const urlPath = decodeURIComponent(req.url.split("?")[0]);
-  const filePath = join(root, urlPath);
+  const filePath = resolve(root, "." + urlPath); // prepend '.' to prevent absolute paths
+  if (!filePath.startsWith(root)) { // path traversal detected
+    res.writeHead(403, {"Content-Type": "text/plain"});
+    res.end("Forbidden");
+    return;
+  }
   try {
     const data = await fs.readFile(filePath);
     const ext = filePath.substring(filePath.lastIndexOf("."));


### PR DESCRIPTION
Potential fix for [https://github.com/Bekalah/liber-arcanae-game/security/code-scanning/3](https://github.com/Bekalah/liber-arcanae-game/security/code-scanning/3)

To fix this vulnerability, we should ensure that any file path served is strictly within the intended document root. We do this by normalizing the constructed path (using `resolve` or `join`), then checking that the result actually starts with the normalized root directory. On Linux/macOS, paths outside the root would not start with the root path. On Windows, we should use the correct path separators. 

A robust fix involves:
- Resolving (normalizing) the joined path.
- Verifying it begins with the root directory’s resolved path.
- If the check fails, responding with 403 Forbidden.
- Making sure symbolic links are not abused (optionally use fs.realpath, but for dev a simple path check is sufficient).

Changes are all within `tools/dev-server.mjs`. We’ll edit the handler code in the `http.createServer()` block: lines 26–37. We’ll normalize and check the path before serving.

No new methods or definitions are needed; only built-in `path` and `fs` functionality will be used.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
