### PR TITLE
Potential fix for code scanning alert no. 4: Uncontrolled data used in path expression

### DIFF
--- a/tools/dev-server.js
+++ b/tools/dev-server.js
@@ -1,23 +1,26 @@
 // Simple static server exposing parent directory so sibling repos resolve via ../repo paths.
 import http from 'node:http';
-import {readFile, stat} from 'node:fs/promises';
+import {readFile, stat, realpath} from 'node:fs/promises';
 import path from 'node:path';
 import {fileURLToPath} from 'node:url';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const root = path.resolve(__dirname, '..'); // parent directory
+let rootRealPathPromise = realpath(root);
 
 const server = http.createServer(async (req, res) => {
   const reqPath = path.normalize(decodeURI(req.url.split('?')[0]));
   let filePath = path.join(root, reqPath);
-  // Validate that the file path is inside the root directory
-  const absPath = path.resolve(filePath);
-  if (!absPath.startsWith(root + path.sep)) {
-    res.writeHead(403);
-    res.end('Forbidden');
-    return;
-  }
   try {
+    const rootRealPath = await rootRealPathPromise;
+    // Resolve the real path of the requested file
+    let absPath = await realpath(path.resolve(filePath));
+    // Check if the path is within the rootRealPath
+    if (!(absPath === rootRealPath || absPath.startsWith(rootRealPath + path.sep))) {
+      res.writeHead(403);
+      res.end('Forbidden');
+      return;
+    }
     const info = await stat(absPath);
     if (info.isDirectory()) absPath = path.join(absPath, 'index.html');
     const data = await readFile(absPath);


### PR DESCRIPTION
Potential fix for [https://github.com/Bekalah/liber-arcanae-game/security/code-scanning/4](https://github.com/Bekalah/liber-arcanae-game/security/code-scanning/4)

To robustly prevent directory traversal, the server must ensure that any file read is within the intended root directory, even when symlinks are involved. The best practice is:
- Normalize the request path using `path.resolve`.
- Resolve the real path, following symlinks, using `await fs.promises.realpath()` before reading or checking file stats.
- After resolving, ensure the real path starts with the root's real path followed by a separator; otherwise, forbid the request.

To implement this:
- Get the real path of the root folder once at startup.
- When handling requests, after resolving the file path, call `await realpath(filePath)` to resolve symlinks.
- Only read or stat the file if the real path starts with the root's real path plus a path separator (or equals the root path).
- Slightly change the code in the request handler to use `realpath` and the real root when checking containment.
- Import `realpath` from `node:fs/promises`.

No changes to the actual functionality (the server continues to serve files in the same way).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
